### PR TITLE
Small code touch ups

### DIFF
--- a/Haystack/searchresult.py
+++ b/Haystack/searchresult.py
@@ -279,7 +279,7 @@ def _is_plural_wildcard(text: str) -> bool:
     return bool(re.search("^\$M_[A-Za-z_]+[0-9]*(;)?$", text))
 
 
-def _strip_from_wildcards(root):
+def _strip_from_wildcards(root: lal.AdaNode) -> lal.AdaNode:
     new_children = [
         i for i in root.children if not i.text or not _is_plural_wildcard(i.text)
     ]

--- a/haystack_plugin.py
+++ b/haystack_plugin.py
@@ -161,8 +161,8 @@ class MainView(Gtk.Grid):
         previous_button = Gtk.Button(label="Previous")
         previous_button.connect("clicked", self.on_previous_clicked)
 
-        replace_next_button = Gtk.Button(label="Replace next")
-        replace_next_button.connect("clicked", self.on_replace_next_clicked)
+        replace_find_button = Gtk.Button(label="Replace & Find")
+        replace_find_button.connect("clicked", self.on_replace_find_clicked)
 
         replace_button = Gtk.Button(label="Replace All")
         replace_button.connect("clicked", self.on_replace_all_clicked)
@@ -170,7 +170,7 @@ class MainView(Gtk.Grid):
         self.contextual_buttons = [
             next_button,
             previous_button,
-            replace_next_button,
+            replace_find_button,
             replace_button,
         ]
         self.set_button_sensitivity(False)
@@ -179,7 +179,7 @@ class MainView(Gtk.Grid):
 
         button_box.pack_start(self.case_insensitive_button, False, False, 0)
         button_box.pack_end(replace_button, False, False, 0)
-        button_box.pack_end(replace_next_button, False, False, 0)
+        button_box.pack_end(replace_find_button, False, False, 0)
         button_box.pack_end(previous_button, False, False, 0)
         button_box.pack_end(next_button, False, False, 0)
         button_box.pack_end(find_all_button, False, False, 0)
@@ -328,7 +328,7 @@ class MainView(Gtk.Grid):
             (filepath, location) = self.locations[self.selected_location]
             select_location(filepath, location)
 
-    def on_replace_next_clicked(self, widget):
+    def on_replace_find_clicked(self, widget):
         """When a search query has been executed, replaces the currently selected location
         and then selects the next matched location in the current file."""
         # Read replace buffer


### PR DESCRIPTION
Renamed the "Replace Next" button in the front-end to "Replace & Find". Also renamed the button itself and its corresponding method name to reflect this change.
Added typing annotations to the _strip_from_wildcards() method in the SearchResult class.